### PR TITLE
Fix bug when loading model with head

### DIFF
--- a/src_files/models/utils/factory.py
+++ b/src_files/models/utils/factory.py
@@ -44,11 +44,11 @@ def create_model(args,load_head=False):
             model_path = "./tresnet_l.pth"
             print('done')
         state = torch.load(model_path, map_location='cpu')
+        if 'model' in state:
+            key = 'model'
+        else:
+            key = 'state_dict'
         if not load_head:
-            if 'model' in state:
-                key = 'model'
-            else:
-                key = 'state_dict'
             filtered_dict = {k: v for k, v in state[key].items() if
                              (k in model.state_dict() and 'head.fc' not in k)}
             model.load_state_dict(filtered_dict, strict=False)


### PR DESCRIPTION
When loading a model with `load_head=True` it would throw an exception because the `key` variable isn't defined. This PR moves the variable definition to fix this bug.